### PR TITLE
Improve the question prompt to be non-case-sensitive

### DIFF
--- a/util/util.py
+++ b/util/util.py
@@ -12,6 +12,6 @@ def print_log(logs):
 
 def binary_prompt(question):
   answer = None
-  while answer == None or answer not in ["Yes", "No"]:
-    answer = input(question + " (Yes/No):")
-  return answer == "Yes"
+  while answer == None or answer not in ["yes", "no"]:
+    answer = input(question + " (Yes/No):").lower()
+  return answer == "yes"


### PR DESCRIPTION
The prompt was not accept "yes" or "no" as an answer, only "Yes" or "No". 
This commit changes the behaviour to be accepting both upper case and lower case answer.

Before:
<img width="460" alt="Screenshot 2023-03-27 at 3 05 06 PM" src="https://user-images.githubusercontent.com/57304483/228044010-f1119f3f-4856-41e5-a483-348c723fb85a.png">


After
<img width="438" alt="Screenshot 2023-03-27 at 3 11 08 PM" src="https://user-images.githubusercontent.com/57304483/228043941-3db9e3e0-4f51-480e-8f77-8ac3ce778471.png">